### PR TITLE
v3.6: Add GTM Consent Mode, Amazon Consent, Custom Attributes, and Match ID Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Enable Advanced Matching to pass hashed user data (email, phone number, or Match
 If operating in GDPR regions, enable TCFv2 to pass consent signals (GDPR applicability, consent string, personal data flag) with your events.
 
 ### Amazon Consent
-Enable this section to pass Amazon Consent Signal (ACS) data with your events. When enabled, the template injects `amzn-consent.js` and calls `window.amznConsent()` with your configured values.
+Check **Enabled** to pass Amazon Consent Signal (ACS) data with your events.
 
 **Fields:**
 - **Country Code** (required) — ISO 3166 two-letter code indicating the legal origin of the request (e.g., US, GB, DE, JP)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,20 @@ Enable Advanced Matching to pass hashed user data (email, phone number, or Match
 If operating in GDPR regions, enable TCFv2 to pass consent signals (GDPR applicability, consent string, personal data flag) with your events.
 
 ### Amazon Consent
-For Amazon's proprietary consent format, configure geo attributes (IP address, country code), Amazon ad storage/user data consent values, and GPP string.
+Enable this section to pass Amazon Consent Signal (ACS) data with your events. When enabled, the template injects `amzn-consent.js` and calls `window.amznConsent()` with your configured values.
+
+**Fields:**
+- **Country Code** (required) — ISO 3166 two-letter code indicating the legal origin of the request (e.g., US, GB, DE, JP)
+- **IP Address** — optional, the user's IP address for geo determination
+- **Amazon Ad Storage** — consent for ad storage. Accepted values: `GRANTED`, `DENIED`, `true`, `false`
+- **Amazon User Data** — consent for user data processing. Accepted values: `GRANTED`, `DENIED`, `true`, `false`
+- **Global Privacy Platform string** — optional IAB GPP consent string from your CMP
+
+**Notes:**
+- Country code is always required for Amazon to process your data
+- For EEA traffic, you must provide at least one consent signal (TCF, GPP, or ACS)
+- If multiple signals are provided, Amazon uses TCF and ignores ACS
+- The consent library defaults all signals to DENIED until explicitly set
 
 ## Consent Mode
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,58 @@
-## Amazon Advertising Tag - GTM Template
+# Amazon Advertising Tag - GTM Template
 
-This repository hosts the Google Tag Manager template for Amazon Ad Tag.
+This repository hosts the Google Tag Manager (GTM) custom tag template for Amazon Advertising. It enables advertisers to deploy Amazon Ad Tags through GTM for conversion tracking, audience building, and attribution.
 
+## Getting Started
+
+1. In Google Tag Manager, go to **Templates > Tag Templates > Search Gallery**
+2. Search for "Amazon Advertising Tag" and add it to your workspace
+3. Create a new tag using the template
+4. Enter your Tag ID(s) from Amazon DSP
+5. Select your event name and region
+6. Configure your trigger and publish
+
+## Configuration
+
+### Tag IDs
+Add a Tag ID provided by Amazon DSP. These identify your advertiser account for conversion tracking.
+
+### Event Name
+Choose a **Standard** event (PageView, AddToShoppingCart, Checkout, Signup, Lead, Off-AmazonPurchases, etc.) or define a **Custom** event name.
+
+### Region
+Select the region that matches your Amazon DSP account:
+- **NA** — North America, South America, Japan, and Australia
+- **EU** — Europe
+
+### Advanced Matching
+Enable Advanced Matching to pass hashed user data (email, phone number, or Match ID) for improved attribution accuracy.
+
+### Attributes
+- **Default Attributes** — key-value pairs sent with standard events (value, brand, category, productId, attr1–attr10)
+- **Off-AmazonPurchase Attributes** — includes currencyCode, unitsSold, and value in addition to standard attributes
+- **Custom Attributes** — arbitrary key-value pairs for custom reporting
+
+### TCFv2
+If operating in GDPR regions, enable TCFv2 to pass consent signals (GDPR applicability, consent string, personal data flag) with your events.
+
+### Amazon Consent
+For Amazon's proprietary consent format, configure geo attributes (IP address, country code), Amazon ad storage/user data consent values, and GPP string.
+
+## Consent Mode
+
+This template integrates with [GTM's native Consent Mode](https://support.google.com/tagmanager/answer/10718549). It declares `access_consent` permissions for `ad_storage` and `ad_user_data`, and uses the `isConsentGranted` API to check consent state before firing.
+
+**How it works:**
+
+- If `ad_storage` or `ad_user_data` consent is denied, the tag will not fire.
+- If consent is later granted (e.g. user accepts a cookie banner), the tag will fire normally on subsequent triggers.
+- If no consent mode is configured in the container, the tag fires as usual with no behavior change.
+
+**No additional setup required.** If your GTM container already has a Consent Management Platform (CMP) configured, the Amazon Ad Tag will automatically respect those consent signals.
+
+## Version
+
+Current version: **3.6**
 
 ## Security
 
@@ -10,4 +61,3 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 ## License
 
 This project is licensed under the Apache-2.0 License.
-

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://advertising.amazon.com"
 documentation: "https://advertising.amazon.com/dsp/help#/"
 versions:
+  - sha: TBD
+    changeNotes: v3.6 - Add GTM Consent Mode, Amazon Consent Signal (ACS), expanded attributes, and tests
   - sha: f37eb4df4e9ac49157b81bf8e15b1b16d792b3a4
     changeNotes: Update GTM template to ignore events sent by gtm-msr
   - sha: 1a497bc5206bb3dd179fcef6c054f6c2fb84ac08

--- a/template.tpl
+++ b/template.tpl
@@ -1,4 +1,4 @@
-﻿___TERMS_OF_SERVICE___
+___TERMS_OF_SERVICE___
 
 By creating or modifying this file you agree to Google Tag Manager's Community
 Template Gallery Developer Terms of Service available at
@@ -24,7 +24,7 @@ ___INFO___
     "ATTRIBUTION",
     "CONVERSIONS"
   ],
-  "description": "Amazon Advertising Tag template - version 3.4",
+  "description": "Amazon Advertising Tag template - version 3.6",
   "containerContexts": [
     "WEB"
   ]
@@ -188,6 +188,10 @@ ___TEMPLATE_PARAMETERS___
               {
                 "value": "phone",
                 "displayValue": "Phone Number"
+              },
+              {
+                "value": "MATCH_ID",
+                "displayValue": "Match ID"
               }
             ],
             "valueValidators": [],
@@ -263,6 +267,58 @@ ___TEMPLATE_PARAMETERS___
               {
                 "value": "value",
                 "displayValue": "value"
+              },
+              {
+                "value": "brand",
+                "displayValue": "brand"
+              },
+              {
+                "value": "category",
+                "displayValue": "category"
+              },
+              {
+                "value": "productId",
+                "displayValue": "productId"
+              },
+              {
+                "value": "attr1",
+                "displayValue": "attr1"
+              },
+              {
+                "value": "attr2",
+                "displayValue": "attr2"
+              },
+              {
+                "value": "attr3",
+                "displayValue": "attr3"
+              },
+              {
+                "value": "attr4",
+                "displayValue": "attr4"
+              },
+              {
+                "value": "attr5",
+                "displayValue": "attr5"
+              },
+              {
+                "value": "attr6",
+                "displayValue": "attr6"
+              },
+              {
+                "value": "attr7",
+                "displayValue": "attr7"
+              },
+              {
+                "value": "attr8",
+                "displayValue": "attr8"
+              },
+              {
+                "value": "attr9",
+                "displayValue": "attr9"
+              },
+              {
+                "value": "attr10",
+                "displayValue": "attr10"
               }
             ]
           },
@@ -305,6 +361,58 @@ ___TEMPLATE_PARAMETERS___
               {
                 "value": "value",
                 "displayValue": "value"
+              },
+              {
+                "value": "brand",
+                "displayValue": "brand"
+              },
+              {
+                "value": "category",
+                "displayValue": "category"
+              },
+              {
+                "value": "productId",
+                "displayValue": "productId"
+              },
+              {
+                "value": "attr1",
+                "displayValue": "attr1"
+              },
+              {
+                "value": "attr2",
+                "displayValue": "attr2"
+              },
+              {
+                "value": "attr3",
+                "displayValue": "attr3"
+              },
+              {
+                "value": "attr4",
+                "displayValue": "attr4"
+              },
+              {
+                "value": "attr5",
+                "displayValue": "attr5"
+              },
+              {
+                "value": "attr6",
+                "displayValue": "attr6"
+              },
+              {
+                "value": "attr7",
+                "displayValue": "attr7"
+              },
+              {
+                "value": "attr8",
+                "displayValue": "attr8"
+              },
+              {
+                "value": "attr9",
+                "displayValue": "attr9"
+              },
+              {
+                "value": "attr10",
+                "displayValue": "attr10"
               }
             ]
           },
@@ -441,13 +549,73 @@ ___TEMPLATE_PARAMETERS___
         "defaultValue": -1
       }
     ]
+  },
+  {
+    "type": "GROUP",
+    "name": "amazonConsent",
+    "displayName": "Amazon Consent",
+    "groupStyle": "ZIPPY_CLOSED",
+    "subParams": [
+      {
+        "type": "CHECKBOX",
+        "name": "enabled",
+        "checkboxText": "Enabled",
+        "simpleValueType": true
+      },
+      {
+        "type": "GROUP",
+        "name": "geo",
+        "displayName": "Geo Attributes",
+        "groupStyle": "ZIPPY_CLOSED",
+        "subParams": [
+          {
+            "type": "TEXT",
+            "name": "ipAddress",
+            "displayName": "IP Address",
+            "simpleValueType": true
+          },
+          {
+            "type": "TEXT",
+            "name": "countryCode",
+            "displayName": "Country Code",
+            "simpleValueType": true
+          }
+        ]
+      },
+      {
+        "type": "GROUP",
+        "name": "amazonConsentFormat",
+        "displayName": "Amazon Consent Format",
+        "groupStyle": "ZIPPY_CLOSED",
+        "subParams": [
+          {
+            "type": "TEXT",
+            "name": "amznAdStorage",
+            "displayName": "Amazon Ad Storage (GRANTED or DENIED)",
+            "simpleValueType": true
+          },
+          {
+            "type": "TEXT",
+            "name": "amznUserData",
+            "displayName": "Amazon User Data (GRANTED or DENIED)",
+            "simpleValueType": true
+          }
+        ]
+      },
+      {
+        "type": "TEXT",
+        "name": "gpp",
+        "displayName": "Global Privacy Platform string",
+        "simpleValueType": true
+      }
+    ]
   }
 ]
 
 
 ___SANDBOXED_JS_FOR_WEB_TEMPLATE___
 
-const version = "3.5";
+const version = "3.6";
 
 const makeTableMap = require('makeTableMap');
 const createArgumentsQueue = require('createArgumentsQueue');
@@ -457,12 +625,24 @@ const copyFromWindow = require('copyFromWindow');
 const makeString = require('makeString');
 const makeInteger = require('makeInteger');
 const getUrl = require('getUrl');
+const isConsentGranted = require('isConsentGranted');
 
 const eventSourceUrl = getUrl();
 
 if (eventSourceUrl.indexOf('gtm-msr.appspot.com') !== -1) {
    log("Ignoring events sent by gtm msr: " + eventSourceUrl);
    return data.gtmOnSuccess();
+}
+
+// Consent check - respect GTM Consent Mode for ad_storage and ad_user_data
+if (!isConsentGranted('ad_storage')) {
+  log("Amazon Ad Tag: ad_storage consent not granted. Tag will not fire.");
+  return data.gtmOnSuccess();
+}
+
+if (!isConsentGranted('ad_user_data')) {
+  log("Amazon Ad Tag: ad_user_data consent not granted. Tag will not fire.");
+  return data.gtmOnSuccess();
 }
 
 
@@ -564,6 +744,9 @@ if (data.advancedMatchingList) {
     if (e.paramName === "phone" && paramVal.length > 0) {
       tokenConfig.phonenumber = paramVal;
     }
+    if (e.paramName === "MATCH_ID" && paramVal.length > 0) {
+      finalAttributes["MATCH_ID"] = paramVal;
+    }
   });
 
   if (gdprAatTokenAttributes.gdpr) {
@@ -601,6 +784,10 @@ const trackEvents = () => {
   const amzn = getAmzn();
   if (!amzn) {
      return fail("Amazon Ad Tag not defined in browser window");
+  }
+
+  if (data.amazonConsent && data.amazonConsent.enabled) {
+     amzn('setAmazonConsent', data.amazonConsent);
   }
 
   if (data.advancedMatchingList && ((tokenConfig.email !== '') || (tokenConfig.phonenumber !== ''))) {
@@ -786,6 +973,90 @@ ___WEB_PERMISSIONS___
           "value": {
             "type": 1,
             "string": "any"
+          }
+        }
+      ]
+    },
+    "clientAnnotations": {
+      "isEditedByUser": true
+    },
+    "isRequired": true
+  },
+  {
+    "instance": {
+      "key": {
+        "publicId": "access_consent",
+        "versionId": "1"
+      },
+      "param": [
+        {
+          "key": "consentTypes",
+          "value": {
+            "type": 2,
+            "listItem": [
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "consentType"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "ad_storage"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": false
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "consentType"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "ad_user_data"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": false
+                  }
+                ]
+              }
+            ]
           }
         }
       ]
@@ -1168,13 +1439,84 @@ scenarios:
     runCode(mockData);
     assertApi('gtmOnSuccess').wasCalled();
     assertThat(amznCalls.length).isEqualTo(0);
-setup: |
+- name: Test can handle Amazon Consent
+  code: |2
+
+    mockData.amazonConsent = {
+        enabled: true,
+        geo: {
+          countryCode: "US"
+        }
+      };
+
+    // Call runCode to run the template's code.
+    runCode(mockData);
+
+    assertThat(amznCalls.length).isEqualTo(5);
+    assertThat(amznCalls[0]).isEqualTo(['setAmazonConsent', { enabled: true, geo: { countryCode: "US"} }]);
+    assertThat(amznCalls[1]).isEqualTo(['setRegion', region]);
+    assertThat(amznCalls[2]).isEqualTo(['addTag', tag1]);
+    assertThat(amznCalls[4]).isEqualTo(['trackEvent', eventName, { gtmVersion: version }]);
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Test can handle match ID
+  code: |
+    mockData.advancedMatchingList = [{"paramName":"MATCH_ID","paramValue":"test1234"}];
+    mockData.standardEventName = "Off-AmazonPurchases";
+
+    runCode(mockData);
+
+    assertThat(amznCalls.length).isEqualTo(4);
+
+    assertThat(amznCalls[0]).isEqualTo(['setRegion', region]);
+    assertThat(amznCalls[1]).isEqualTo(['addTag', tag1]);
+    assertThat(amznCalls[2]).isEqualTo(['addtcfv2', {}]);
+    assertThat(amznCalls[3]).isEqualTo(['trackEvent', "Off-AmazonPurchases", {"MATCH_ID":
+    "test1234", "gtmVersion":version}]);
+    assertApi('gtmOnSuccess').wasCalled();
+
+    amznCalls = [];
+- name: Test ad_storage consent denied prevents tag from firing
+  code: |
+    mock('isConsentGranted', (consentType) => {
+      if (consentType === 'ad_storage') return false;
+      return true;
+    });
+
+    runCode(mockData);
+
+    assertThat(amznCalls.length).isEqualTo(0);
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: Test ad_user_data consent denied prevents tag from firing
+  code: |
+    mock('isConsentGranted', (consentType) => {
+      if (consentType === 'ad_user_data') return false;
+      return true;
+    });
+
+    runCode(mockData);
+
+    assertThat(amznCalls.length).isEqualTo(0);
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+- name: Test both ad_storage and ad_user_data denied prevents tag from firing
+  code: |
+    mock('isConsentGranted', (consentType) => {
+      return false;
+    });
+
+    runCode(mockData);
+
+    assertThat(amznCalls.length).isEqualTo(0);
+    assertApi('gtmOnSuccess').wasCalled();
+    assertApi('gtmOnFailure').wasNotCalled();
+setup: |-
   const log = require('logToConsole');
 
   const tag1 = 'tagId1';
   const eventName = 'PageView';
   const region = 'NA';
-  const version = '3.5';
+  const version = '3.6';
   const exampleTCFv2ConsentString = 'COw4XqLOw4XqLAAAAAENAXCAAAAAAAAAAAAAAAAAAAAA.IFukWSQgAIQwgI0QEByFAAAAeIAACAIgSAAQAIAgEQACEABAAAgAQFAEAIAAAGBAAgAAAAQAIFAAMCQAAgAAQiRAEQAAAAANAAIAAggAIYQFAAARmggBC3ZCYzU2yIA.QFukWSQgAIQwgI0QEByFAAAAeIAACAIgSAAQAIAgEQACEABAAAgAQFAEAIAAAGBAAgAAAAQAIFAAMCQAAgAAQiRAEQAAAAANAAIAAggAIYQFAAARmggBC3ZCYzU2yIA.YAAAAAAAAAAAAAAAAAA'; // https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#tc-string-format
 
   const mockData = {
@@ -1211,4 +1553,5 @@ setup: |
 ___NOTES___
 
 Created on 3/26/2020, 3:08:52 PM
+
 

--- a/template.tpl
+++ b/template.tpl
@@ -563,44 +563,33 @@ ___TEMPLATE_PARAMETERS___
         "simpleValueType": true
       },
       {
-        "type": "GROUP",
-        "name": "geo",
-        "displayName": "Geo Attributes",
-        "groupStyle": "ZIPPY_CLOSED",
-        "subParams": [
-          {
-            "type": "TEXT",
-            "name": "ipAddress",
-            "displayName": "IP Address",
-            "simpleValueType": true
-          },
-          {
-            "type": "TEXT",
-            "name": "countryCode",
-            "displayName": "Country Code",
-            "simpleValueType": true
-          }
-        ]
+        "type": "TEXT",
+        "name": "countryCode",
+        "displayName": "Country Code (ISO 3166, e.g. US, GB, DE, JP)",
+        "simpleValueType": true,
+        "valueHint": "US"
       },
       {
-        "type": "GROUP",
-        "name": "amazonConsentFormat",
-        "displayName": "Amazon Consent Format",
-        "groupStyle": "ZIPPY_CLOSED",
-        "subParams": [
-          {
-            "type": "TEXT",
-            "name": "amznAdStorage",
-            "displayName": "Amazon Ad Storage (GRANTED or DENIED)",
-            "simpleValueType": true
-          },
-          {
-            "type": "TEXT",
-            "name": "amznUserData",
-            "displayName": "Amazon User Data (GRANTED or DENIED)",
-            "simpleValueType": true
-          }
-        ]
+        "type": "TEXT",
+        "name": "ipAddress",
+        "displayName": "IP Address",
+        "simpleValueType": true
+      },
+      {
+        "type": "TEXT",
+        "name": "amznAdStorage",
+        "displayName": "Amazon Ad Storage",
+        "simpleValueType": true,
+        "help": "Accepted values: GRANTED, DENIED, true, false",
+        "valueHint": "GRANTED"
+      },
+      {
+        "type": "TEXT",
+        "name": "amznUserData",
+        "displayName": "Amazon User Data",
+        "simpleValueType": true,
+        "help": "Accepted values: GRANTED, DENIED, true, false",
+        "valueHint": "GRANTED"
       },
       {
         "type": "TEXT",
@@ -626,6 +615,7 @@ const makeString = require('makeString');
 const makeInteger = require('makeInteger');
 const getUrl = require('getUrl');
 const isConsentGranted = require('isConsentGranted');
+const callInWindow = require('callInWindow');
 
 const eventSourceUrl = getUrl();
 
@@ -763,7 +753,9 @@ if (data.advancedMatchingList) {
   if (ttl) {
     tokenConfig.ttl = ttl;
   }
-  log("token config =", tokenConfig);
+  log("Amazon Ad Tag: Advanced Matching enabled -",
+    "email:", tokenConfig.email ? "set" : "not set",
+    "phone:", tokenConfig.phonenumber ? "set" : "not set");
 }
 
 // Define amzn fn in window
@@ -786,10 +778,6 @@ const trackEvents = () => {
      return fail("Amazon Ad Tag not defined in browser window");
   }
 
-  if (data.amazonConsent && data.amazonConsent.enabled) {
-     amzn('setAmazonConsent', data.amazonConsent);
-  }
-
   if (data.advancedMatchingList && ((tokenConfig.email !== '') || (tokenConfig.phonenumber !== ''))) {
      amzn('setUserData', tokenConfig);
   }
@@ -797,11 +785,54 @@ const trackEvents = () => {
   amzn('setRegion', region);
   tagIds.forEach(item => amzn("addTag", item));
   amzn('addtcfv2', gdprEventAttributes);
+  if (data.includeTcf) {
+    log("Amazon Ad Tag: TCF consent signal set -",
+      "gdpr:", gdprEventAttributes.gdpr !== undefined ? gdprEventAttributes.gdpr : "not set",
+      "consent string:", gdprEventAttributes.gdpr_consent ? "set" : "not set",
+      "gdpr_pd:", gdprEventAttributes.gdpr_pd !== undefined ? gdprEventAttributes.gdpr_pd : "not set");
+  }
   amzn('trackEvent', eventName, finalAttributes);
+  log("Amazon Ad Tag: fired", eventName, "for", tagIds.length, "tag(s)");
 };
 
-trackEvents();
-injectScript('https://c.amazon-adsystem.com/aat/amzn.js', data.gtmOnSuccess, data.gtmOnFailure, 'amznScript');
+// Set consent via amzn-consent.js before amzn.js loads
+const setAmazonConsent = () => {
+  if (data.enabled && data.countryCode) {
+    const consentData = {
+      countryCode: data.countryCode,
+      enableAdStorage: data.amznAdStorage === 'GRANTED' || data.amznAdStorage === 'true' || data.amznAdStorage === true,
+      enableUserData: data.amznUserData === 'GRANTED' || data.amznUserData === 'true' || data.amznUserData === true
+    };
+
+    if (data.ipAddress) {
+      consentData.ipAddress = data.ipAddress;
+    }
+
+    if (data.gpp) {
+      consentData.gpp = data.gpp;
+    }
+
+    log("Amazon Ad Tag: setAmazonConsent:", consentData);
+    callInWindow('amznConsent', consentData);
+  }
+};
+
+log("Amazon Ad Tag: amazonConsent check:", data.countryCode, data.enabled);
+
+if (data.enabled && data.countryCode) {
+  injectScript('https://c.amazon-adsystem.com/aat/amzn-consent.js', () => {
+    setAmazonConsent();
+    trackEvents();
+    injectScript('https://c.amazon-adsystem.com/aat/amzn.js', data.gtmOnSuccess, data.gtmOnFailure, 'amznScript');
+  }, () => {
+    log("Amazon Ad Tag: amzn-consent.js failed to load.");
+    trackEvents();
+    injectScript('https://c.amazon-adsystem.com/aat/amzn.js', data.gtmOnSuccess, data.gtmOnFailure, 'amznScript');
+  }, 'amznConsentScript');
+} else {
+  trackEvents();
+  injectScript('https://c.amazon-adsystem.com/aat/amzn.js', data.gtmOnSuccess, data.gtmOnFailure, 'amznScript');
+}
 
 
 ___WEB_PERMISSIONS___
@@ -903,6 +934,45 @@ ___WEB_PERMISSIONS___
                   {
                     "type": 1,
                     "string": "amzn.q"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "key"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  },
+                  {
+                    "type": 1,
+                    "string": "execute"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "amznConsent"
                   },
                   {
                     "type": 8,
@@ -1510,6 +1580,102 @@ scenarios:
     assertThat(amznCalls.length).isEqualTo(0);
     assertApi('gtmOnSuccess').wasCalled();
     assertApi('gtmOnFailure').wasNotCalled();
+- name: Test Amazon Consent injects consent library when countryCode is set
+  code: |
+    mockData.enabled = true;
+    mockData.countryCode = 'US';
+    mockData.amznAdStorage = 'GRANTED';
+    mockData.amznUserData = 'GRANTED';
+
+    runCode(mockData);
+
+    assertApi('injectScript').wasCalled();
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Test Amazon Consent calls amznConsent with GRANTED values
+  code: |
+    let amznConsentArgs = null;
+    mock('callInWindow', (fn, args) => {
+      if (fn === 'amznConsent') amznConsentArgs = args;
+    });
+
+    mockData.enabled = true;
+    mockData.countryCode = 'US';
+    mockData.amznAdStorage = 'GRANTED';
+    mockData.amznUserData = 'GRANTED';
+
+    runCode(mockData);
+
+    assertThat(amznConsentArgs).isNotNull();
+    assertThat(amznConsentArgs.countryCode).isEqualTo('US');
+    assertThat(amznConsentArgs.enableAdStorage).isEqualTo(true);
+    assertThat(amznConsentArgs.enableUserData).isEqualTo(true);
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Test Amazon Consent calls amznConsent with DENIED values
+  code: |
+    let amznConsentArgs = null;
+    mock('callInWindow', (fn, args) => {
+      if (fn === 'amznConsent') amznConsentArgs = args;
+    });
+
+    mockData.enabled = true;
+    mockData.countryCode = 'DE';
+    mockData.amznAdStorage = 'DENIED';
+    mockData.amznUserData = 'DENIED';
+
+    runCode(mockData);
+
+    assertThat(amznConsentArgs).isNotNull();
+    assertThat(amznConsentArgs.countryCode).isEqualTo('DE');
+    assertThat(amznConsentArgs.enableAdStorage).isEqualTo(false);
+    assertThat(amznConsentArgs.enableUserData).isEqualTo(false);
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Test Amazon Consent accepts true/false string values
+  code: |
+    let amznConsentArgs = null;
+    mock('callInWindow', (fn, args) => {
+      if (fn === 'amznConsent') amznConsentArgs = args;
+    });
+
+    mockData.enabled = true;
+    mockData.countryCode = 'JP';
+    mockData.amznAdStorage = 'true';
+    mockData.amznUserData = 'false';
+
+    runCode(mockData);
+
+    assertThat(amznConsentArgs).isNotNull();
+    assertThat(amznConsentArgs.enableAdStorage).isEqualTo(true);
+    assertThat(amznConsentArgs.enableUserData).isEqualTo(false);
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Test Amazon Consent includes GPP string when provided
+  code: |
+    let amznConsentArgs = null;
+    mock('callInWindow', (fn, args) => {
+      if (fn === 'amznConsent') amznConsentArgs = args;
+    });
+
+    mockData.enabled = true;
+    mockData.countryCode = 'GB';
+    mockData.amznAdStorage = 'DENIED';
+    mockData.amznUserData = 'DENIED';
+    mockData.gpp = 'DBABLA~BVVqAAAACCA.QA';
+
+    runCode(mockData);
+
+    assertThat(amznConsentArgs).isNotNull();
+    assertThat(amznConsentArgs.gpp).isEqualTo('DBABLA~BVVqAAAACCA.QA');
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Test Amazon Consent skipped when enabled is false
+  code: |
+    mockData.enabled = false;
+    mockData.countryCode = 'US';
+    mockData.amznAdStorage = 'GRANTED';
+    mockData.amznUserData = 'GRANTED';
+
+    runCode(mockData);
+
+    assertApi('callInWindow').wasNotCalled();
+    assertApi('gtmOnSuccess').wasCalled();
 setup: |-
   const log = require('logToConsole');
 

--- a/template.tpl
+++ b/template.tpl
@@ -1509,26 +1509,30 @@ scenarios:
     runCode(mockData);
     assertApi('gtmOnSuccess').wasCalled();
     assertThat(amznCalls.length).isEqualTo(0);
-- name: Test can handle Amazon Consent
-  code: |2
+- name: ACS - consent payload sent with GRANTED values
+  code: |
+    let amznConsentCalled = false;
+    let amznConsentArgs = null;
+    mock('callInWindow', (fn, args) => {
+      if (fn === 'amznConsent') {
+        amznConsentCalled = true;
+        amznConsentArgs = args;
+      }
+    });
 
-    mockData.amazonConsent = {
-        enabled: true,
-        geo: {
-          countryCode: "US"
-        }
-      };
+    mockData.enabled = true;
+    mockData.countryCode = 'US';
+    mockData.amznAdStorage = 'GRANTED';
+    mockData.amznUserData = 'GRANTED';
 
-    // Call runCode to run the template's code.
     runCode(mockData);
 
-    assertThat(amznCalls.length).isEqualTo(5);
-    assertThat(amznCalls[0]).isEqualTo(['setAmazonConsent', { enabled: true, geo: { countryCode: "US"} }]);
-    assertThat(amznCalls[1]).isEqualTo(['setRegion', region]);
-    assertThat(amznCalls[2]).isEqualTo(['addTag', tag1]);
-    assertThat(amznCalls[4]).isEqualTo(['trackEvent', eventName, { gtmVersion: version }]);
+    assertThat(amznConsentCalled).isEqualTo(true);
+    assertThat(amznConsentArgs.countryCode).isEqualTo('US');
+    assertThat(amznConsentArgs.enableAdStorage).isEqualTo(true);
+    assertThat(amznConsentArgs.enableUserData).isEqualTo(true);
     assertApi('gtmOnSuccess').wasCalled();
-- name: Test can handle match ID
+- name: Advanced Matching - match ID passed as event attribute
   code: |
     mockData.advancedMatchingList = [{"paramName":"MATCH_ID","paramValue":"test1234"}];
     mockData.standardEventName = "Off-AmazonPurchases";
@@ -1545,7 +1549,7 @@ scenarios:
     assertApi('gtmOnSuccess').wasCalled();
 
     amznCalls = [];
-- name: Test ad_storage consent denied prevents tag from firing
+- name: Consent Mode - ad_storage denied blocks tag
   code: |
     mock('isConsentGranted', (consentType) => {
       if (consentType === 'ad_storage') return false;
@@ -1557,7 +1561,7 @@ scenarios:
     assertThat(amznCalls.length).isEqualTo(0);
     assertApi('gtmOnSuccess').wasCalled();
     assertApi('gtmOnFailure').wasNotCalled();
-- name: Test ad_user_data consent denied prevents tag from firing
+- name: Consent Mode - ad_user_data denied blocks tag
   code: |
     mock('isConsentGranted', (consentType) => {
       if (consentType === 'ad_user_data') return false;
@@ -1569,7 +1573,7 @@ scenarios:
     assertThat(amznCalls.length).isEqualTo(0);
     assertApi('gtmOnSuccess').wasCalled();
     assertApi('gtmOnFailure').wasNotCalled();
-- name: Test both ad_storage and ad_user_data denied prevents tag from firing
+- name: Consent Mode - both denied blocks tag
   code: |
     mock('isConsentGranted', (consentType) => {
       return false;
@@ -1580,7 +1584,7 @@ scenarios:
     assertThat(amznCalls.length).isEqualTo(0);
     assertApi('gtmOnSuccess').wasCalled();
     assertApi('gtmOnFailure').wasNotCalled();
-- name: Test Amazon Consent injects consent library when countryCode is set
+- name: ACS - consent library injected when countryCode set
   code: |
     mockData.enabled = true;
     mockData.countryCode = 'US';
@@ -1591,7 +1595,7 @@ scenarios:
 
     assertApi('injectScript').wasCalled();
     assertApi('gtmOnSuccess').wasCalled();
-- name: Test Amazon Consent calls amznConsent with GRANTED values
+- name: ACS - GRANTED values passed as true
   code: |
     let amznConsentArgs = null;
     mock('callInWindow', (fn, args) => {
@@ -1610,7 +1614,7 @@ scenarios:
     assertThat(amznConsentArgs.enableAdStorage).isEqualTo(true);
     assertThat(amznConsentArgs.enableUserData).isEqualTo(true);
     assertApi('gtmOnSuccess').wasCalled();
-- name: Test Amazon Consent calls amznConsent with DENIED values
+- name: ACS - DENIED values passed as false
   code: |
     let amznConsentArgs = null;
     mock('callInWindow', (fn, args) => {
@@ -1629,7 +1633,7 @@ scenarios:
     assertThat(amznConsentArgs.enableAdStorage).isEqualTo(false);
     assertThat(amznConsentArgs.enableUserData).isEqualTo(false);
     assertApi('gtmOnSuccess').wasCalled();
-- name: Test Amazon Consent accepts true/false string values
+- name: ACS - true/false strings accepted
   code: |
     let amznConsentArgs = null;
     mock('callInWindow', (fn, args) => {
@@ -1647,7 +1651,7 @@ scenarios:
     assertThat(amznConsentArgs.enableAdStorage).isEqualTo(true);
     assertThat(amznConsentArgs.enableUserData).isEqualTo(false);
     assertApi('gtmOnSuccess').wasCalled();
-- name: Test Amazon Consent includes GPP string when provided
+- name: ACS - GPP string included in payload
   code: |
     let amznConsentArgs = null;
     mock('callInWindow', (fn, args) => {
@@ -1665,7 +1669,7 @@ scenarios:
     assertThat(amznConsentArgs).isNotNull();
     assertThat(amznConsentArgs.gpp).isEqualTo('DBABLA~BVVqAAAACCA.QA');
     assertApi('gtmOnSuccess').wasCalled();
-- name: Test Amazon Consent skipped when enabled is false
+- name: ACS - skipped when disabled
   code: |
     mockData.enabled = false;
     mockData.countryCode = 'US';


### PR DESCRIPTION
## Summary

Upgrades the Amazon Advertising GTM template from v3.5 to v3.6 so Google Tag Manager Gallery can inherit the latest template changes. Update README to include lightweight instructions for implementation ease.

## Changes

### GTM Consent Mode Integration
- Template now checks `ad_storage` and `ad_user_data` via `isConsentGranted` before firing
- If either consent type is denied, the tag exits gracefully (no network calls, no errors)
- Added `access_consent` permission declarations for `ad_storage` and `ad_user_data` (read-only)
- Tags created from this template will show Built-In Consent Checks in GTM's Consent Settings

### Amazon Consent
- New UI section for Amazon's proprietary consent format
- Supports geo attributes (IP address, country code), Amazon ad storage/user data consent values, and GPP string
- When enabled, calls `amzn('setAmazonConsent', ...)` before other tracking calls

### Match ID Support
- Added "Match ID" as an Advanced Matching parameter option
- Match ID values are passed as an event attribute rather than token config

### Expanded Attributes
- Off-AmazonPurchase Attributes and Default Attributes now include: brand, category, productId, attr1–attr10

### Other
- Version bump: 3.5 → 3.6 (description field + runtime constant)
- Expanded README with setup instructions, configuration docs, and consent mode explanation

## Tests Added
- `Test ad_storage consent denied prevents tag from firing`
- `Test ad_user_data consent denied prevents tag from firing`
- `Test both ad_storage and ad_user_data denied prevents tag from firing`
- `Test can handle Amazon Consent`
- `Test can handle match ID`

## Testing
- Verified in GTM Preview Mode with consent defaulting to denied — tag correctly blocked on page load
- Verified tag fires normally when consent is granted
- Built-In Consent Checks (`ad_storage`, `ad_user_data`) appear automatically on new tag instances

