### PR TITLE
Update metadata SHA for v4.0 release

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://advertising.amazon.com"
 documentation: "https://advertising.amazon.com/dsp/help#/"
 versions:
+  - sha: 94e6f66b4e229d6f9feeee4e0de46f22be9e290d
+    changeNotes: v4.0 - Add GA4 ecommerce auto-read, client deduplication ID, and configuration mode selector
   - sha: b331cc2b8fa8f4fa4de15898c9565c7b591026ba
     changeNotes: v3.6 - Add GTM Consent Mode, Amazon Consent Signal (ACS), expanded attributes, and tests
   - sha: f37eb4df4e9ac49157b81bf8e15b1b16d792b3a4


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Adds the v4.0 release commit (94e6f66) to metadata.yaml, following the same pattern used for the v3.6 entry. Records the GA4 ecommerce auto-read, client deduplication ID, and configuration mode selector changes from PR #25